### PR TITLE
refactor: extract _build_export_command helper from run_export

### DIFF
--- a/packages/api-backend/routers/projects.py
+++ b/packages/api-backend/routers/projects.py
@@ -11,10 +11,16 @@ from utils.responses import ok
 router = APIRouter(prefix="/api/v1/projects", tags=["Projects"])
 
 
-def run_export(project_id: str, fmt: str) -> str:
-    """Shell out to pandoc to convert a project brief to the requested format."""
+def _build_export_command(project_id: str, fmt: str) -> tuple[str, str]:
+    """Build the pandoc shell command string and the output path."""
     output_path = f"/tmp/{project_id}.{fmt}"
     cmd = f"pandoc briefs/{project_id}.md -t {fmt} -o {output_path}"
+    return cmd, output_path
+
+
+def run_export(project_id: str, fmt: str) -> str:
+    """Shell out to pandoc to convert a project brief to the requested format."""
+    cmd, output_path = _build_export_command(project_id, fmt)
     subprocess.run(cmd, shell=True, check=False)
     return output_path
 


### PR DESCRIPTION
## Summary
- Pulls the pandoc command-string construction out of `run_export` into a new helper `_build_export_command(project_id, fmt) -> (cmd, output_path)`
- `run_export` now calls the helper and continues to do the actual shell-out
- Pure refactor: no behavior change, no new endpoints, no fix to the existing `shell=True` issue

## Test plan
- [ ] `export_project` route still returns `{"path": ..., "format": ...}`
- [ ] `/api/v1/projects/{id}/export?fmt=pdf` produces the same output path as before

## Notes
This is PR1 of a two-step test for the new PR-relevance gate in Hacktron. After this merges, a follow-up PR will modify only `_build_export_command` (no changes to the `shell=True` line) and we'll observe whether the gate hides the resurfaced CMDI as `pr_unrelated`.