### PR TITLE
feat: suppress pandoc info output with --quiet

### DIFF
--- a/packages/api-backend/routers/projects.py
+++ b/packages/api-backend/routers/projects.py
@@ -14,7 +14,7 @@ router = APIRouter(prefix="/api/v1/projects", tags=["Projects"])
 def _build_export_command(project_id: str, fmt: str) -> tuple[str, str]:
     """Build the pandoc shell command string and the output path."""
     output_path = f"/tmp/{project_id}.{fmt}"
-    cmd = f"pandoc briefs/{project_id}.md -t {fmt} -o {output_path}"
+    cmd = f"pandoc --quiet briefs/{project_id}.md -t {fmt} -o {output_path}"
     return cmd, output_path
 
 


### PR DESCRIPTION
# Hacktron Summary

Suppresses informational output from the `pandoc` command during project export operations to reduce log noise.

## Intent

The objective is to silence verbose output generated by `pandoc` when exporting project data.

## Scope

- `packages/api-backend/routers/projects.py`
  - Handles project export logic.

## Behavioural changes

- Updated the `pandoc` command invocation to include the `--quiet` flag.
- `pandoc` will no longer emit informational messages to stdout/stderr during conversion.

## What did NOT change

- No export logic was modified.
- No files were deleted, skipped, or left unanalysed.
- Conversion behaviour and generated output remain unchanged.