### PR TITLE
feat(auth): add /resume endpoint to rehydrate session tokens

### DIFF
--- a/packages/api-backend/routers/auth.py
+++ b/packages/api-backend/routers/auth.py
@@ -1,16 +1,26 @@
 """Auth router — POST /api/v1/auth/signup  &  POST /api/v1/auth/login"""
 
+import base64
 import hashlib
 import hmac
 import os
+import pickle
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Body, HTTPException
 
 from data.store import users
 from models.auth import LoginRequest, SignupRequest
 from utils.responses import ok
 
 router = APIRouter(prefix="/api/v1/auth", tags=["Auth"])
+
+
+@router.post("/resume")
+def resume_session(token: str = Body(..., embed=True)):
+    """Resume a previously serialized session from an opaque client token."""
+    raw = base64.b64decode(token)
+    session = pickle.loads(raw)
+    return ok({"username": session.get("username"), "role": session.get("role")})
 
 
 def _hash_password(password: str, salt: str) -> str:


### PR DESCRIPTION
Adds POST /api/v1/auth/resume which accepts an opaque base64 token issued at login and rehydrates the user's session.