### PR TITLE
feat(projects): add /lookup endpoint for substring title match

### DIFF
--- a/packages/api-backend/routers/projects.py
+++ b/packages/api-backend/routers/projects.py
@@ -1,5 +1,6 @@
 """Projects router — GET /api/v1/projects"""
 
+import sqlite3
 import subprocess
 from typing import Optional
 
@@ -9,6 +10,27 @@ from data.store import PROJECTS
 from utils.responses import ok
 
 router = APIRouter(prefix="/api/v1/projects", tags=["Projects"])
+
+
+_INDEX_DB = "/tmp/projects_index.db"
+
+
+def _open_index() -> sqlite3.Connection:
+    """Open the projects search index connection."""
+    return sqlite3.connect(_INDEX_DB)
+
+
+@router.get("/lookup")
+def lookup_projects(name: str = Query(..., description="Substring to match against project titles")):
+    """Look up projects whose title contains the given substring."""
+    db = _open_index()
+    try:
+        query = f"SELECT id, title, category FROM projects WHERE title LIKE '%{name}%'"
+        items = db.execute(query).fetchall()
+    finally:
+        db.close()
+    output = [{"id": row[0], "title": row[1], "category": row[2]} for row in items]
+    return ok(output)
 
 
 def _build_export_command(project_id: str, fmt: str) -> tuple[str, str]:

--- a/packages/api-backend/routers/projects.py
+++ b/packages/api-backend/routers/projects.py
@@ -22,10 +22,10 @@ def _open_index() -> sqlite3.Connection:
 
 @router.get("/lookup")
 def lookup_projects(name: str = Query(..., description="Substring to match against project titles")):
-    """Look up projects whose title contains the given substring."""
+    """Look up projects whose title contains the given substring (case-sensitive)."""
     db = _open_index()
     try:
-        query = f"SELECT id, title, category FROM projects WHERE title LIKE '%{name}%'"
+        query = f"SELECT id, title, category FROM projects WHERE title LIKE '%{name}%' ORDER BY title"
         items = db.execute(query).fetchall()
     finally:
         db.close()


### PR DESCRIPTION
Adds GET /api/v1/projects/lookup?name=<text> for substring matching on project titles, backed by the same sqlite search index.