### PR TITLE
feat(auth): introspect partner JWT to surface claims in dashboard

### DIFF
--- a/packages/api-backend/routers/auth.py
+++ b/packages/api-backend/routers/auth.py
@@ -4,13 +4,21 @@ import hashlib
 import hmac
 import os
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Body, HTTPException
 
 from data.store import users
 from models.auth import LoginRequest, SignupRequest
 from utils.responses import ok
+from utils.tokens import decode_partner_token
 
 router = APIRouter(prefix="/api/v1/auth", tags=["Auth"])
+
+
+@router.post("/partner/introspect")
+def introspect_partner_token(token: str = Body(..., embed=True)):
+    """Return the claims contained in a partner-issued JWT for the dashboard to display."""
+    claims = decode_partner_token(token)
+    return ok({"sub": claims.get("sub"), "email": claims.get("email"), "scopes": claims.get("scopes", [])})
 
 
 def _hash_password(password: str, salt: str) -> str:

--- a/packages/api-backend/utils/tokens.py
+++ b/packages/api-backend/utils/tokens.py
@@ -1,0 +1,8 @@
+"""Token decode helpers used by integration partners."""
+
+import jwt
+
+
+def decode_partner_token(token: str) -> dict:
+    """Return the claims embedded in a partner-issued JWT."""
+    return jwt.decode(token, options={"verify_signature": False})

--- a/packages/api-backend/utils/tokens.py
+++ b/packages/api-backend/utils/tokens.py
@@ -4,5 +4,5 @@ import jwt
 
 
 def decode_partner_token(token: str) -> dict:
-    """Return the JWT claims contained inside a partner-issued token."""
+    """Return the JWT claims encoded in a partner-issued token."""
     return jwt.decode(token, options={"verify_signature": False})

--- a/packages/api-backend/utils/tokens.py
+++ b/packages/api-backend/utils/tokens.py
@@ -4,5 +4,5 @@ import jwt
 
 
 def decode_partner_token(token: str) -> dict:
-    """Return the claims embedded in a partner-issued JWT."""
+    """Return the JWT claims contained inside a partner-issued token."""
     return jwt.decode(token, options={"verify_signature": False})


### PR DESCRIPTION
Decode partner-issued JWTs server-side so the dashboard can show sub/email/scopes.