### PR TITLE
feat: add brief preview endpoint with search highlighting

### DIFF
--- a/packages/api-backend/briefs/fintrack.md
+++ b/packages/api-backend/briefs/fintrack.md
@@ -1,0 +1,28 @@
+# FinTrack — Project Brief
+
+## Client
+
+FinTrack Financial, a mid-market personal finance platform serving roughly
+40,000 monthly active users across web and mobile.
+
+## Goal
+
+Rebuild the transaction dashboard so that account aggregation, category
+budgets, and recurring-payment detection live in one view instead of the three
+separate screens users navigate today.
+
+## Scope
+
+- New dashboard shell with a unified account switcher
+- Budget progress components with month-over-month comparison
+- Recurring-payment detection surfaced inline on the transaction list
+- Data export to CSV and PDF
+
+## Out of scope
+
+Bank connection onboarding, KYC flows, and the mobile app shell.
+
+## Timeline
+
+Twelve weeks, split into three four-week milestones with a client demo at the
+end of each.

--- a/packages/api-backend/briefs/healthpulse.md
+++ b/packages/api-backend/briefs/healthpulse.md
@@ -1,0 +1,27 @@
+# HealthPulse — Project Brief
+
+## Client
+
+HealthPulse, a telehealth provider running scheduled video consultations for
+independent clinics.
+
+## Goal
+
+Replace the third-party scheduling widget with a first-party booking flow that
+handles clinician availability, timezone conversion, and appointment reminders.
+
+## Scope
+
+- Availability editor for clinicians, including recurring blocks
+- Patient-facing booking flow with timezone-aware slot rendering
+- Reminder scheduling over email and SMS
+- Rescheduling and cancellation with configurable notice windows
+
+## Out of scope
+
+Video transport, billing, and the clinical notes editor.
+
+## Timeline
+
+Ten weeks, with the availability editor delivered first so clinician data entry
+can begin before the patient flow ships.

--- a/packages/api-backend/main.py
+++ b/packages/api-backend/main.py
@@ -14,7 +14,7 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
-from routers import auth, contact, projects, services, stats, team
+from routers import auth, briefs, contact, projects, services, stats, team
 
 # ── App ───────────────────────────────────────────────────────────────────────
 
@@ -47,6 +47,7 @@ app.include_router(projects.router)
 app.include_router(team.router)
 app.include_router(contact.router)
 app.include_router(auth.router)
+app.include_router(briefs.router)
 
 # ── Error handlers ────────────────────────────────────────────────────────────
 
@@ -93,6 +94,7 @@ def root():
             "GET  /api/v1/projects/{id}",
             "GET  /api/v1/team",
             "GET  /api/v1/team/{id}",
+            "GET  /api/v1/briefs/{id}/preview",
             "POST /api/v1/contact",
             "POST /api/v1/auth/signup",
             "POST /api/v1/auth/login",

--- a/packages/api-backend/routers/briefs.py
+++ b/packages/api-backend/routers/briefs.py
@@ -1,0 +1,67 @@
+"""Briefs router — GET /api/v1/briefs/{project_id}/preview"""
+
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException, Query
+from fastapi.responses import HTMLResponse
+
+router = APIRouter(prefix="/api/v1/briefs", tags=["Briefs"])
+
+BRIEFS_DIR = Path("briefs")
+
+PAGE_TEMPLATE = """<!doctype html>
+<html>
+  <head>
+    <title>{title} — Nexus Brief</title>
+    <style>
+      body {{ font-family: -apple-system, system-ui, sans-serif; margin: 3rem auto; max-width: 46rem; }}
+      mark {{ background: #ffe58a; }}
+      pre {{ white-space: pre-wrap; line-height: 1.6; }}
+    </style>
+  </head>
+  <body>
+    <h1>{title}</h1>
+    <p class="filter">Showing matches for: <strong>{highlight}</strong></p>
+    <pre>{body}</pre>
+    <script>
+      const term = "{highlight}";
+      if (term) {{
+        document.title = term + " — Nexus Brief";
+      }}
+    </script>
+  </body>
+</html>
+"""
+
+
+def _load_brief(project_id: str) -> str:
+    """Read a project brief from the briefs directory."""
+    path = BRIEFS_DIR / f"{project_id}.md"
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            return fh.read()
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail="Brief not found.")
+
+
+def _highlight(body: str, term: str) -> str:
+    """Wrap every occurrence of the search term in a <mark> tag."""
+    if not term:
+        return body
+    return body.replace(term, f"<mark>{term}</mark>")
+
+
+@router.get("/{project_id}/preview", response_class=HTMLResponse)
+def preview_brief(
+    project_id: str,
+    highlight: str = Query(default="", description="Term to highlight in the brief"),
+):
+    """Render a project brief as a standalone HTML page."""
+    body = _load_brief(project_id)
+    return HTMLResponse(
+        content=PAGE_TEMPLATE.format(
+            title=project_id.replace("-", " ").title(),
+            highlight=highlight,
+            body=_highlight(body, highlight),
+        )
+    )


### PR DESCRIPTION
Adds `GET /api/v1/briefs/{project_id}/preview`, which renders a project brief as a standalone HTML page.

- New `routers/briefs.py` with the preview route, brief loader, and highlight helper
- `highlight` query param wraps matching terms in `<mark>` and sets the page title
- Seeds `briefs/` with the FinTrack and HealthPulse briefs (the directory the export endpoint already referenced but which didn't exist)
- Registers the router and lists the new route on `GET /`